### PR TITLE
Fix broken removeProduct

### DIFF
--- a/src/Candles.js
+++ b/src/Candles.js
@@ -50,7 +50,7 @@ class candles extends EventEmitter {
       this.clock.start();
     }
     var series = new Series(product, timeframe, serieslength);
-    this.clock.on('tick '+ timeframe, series.onSeriesClockTick.bind(series));
+    this.clock.on('tick ' + timeframe, series.onSeriesClockTick);
     series.on('open',this.seriesOpen.bind(this));
     series.on('close',this.seriesClose.bind(this));
     if (!this.series[product]) {
@@ -68,9 +68,9 @@ class candles extends EventEmitter {
 
   removeProduct(product, timeframe) {
     if (this.series[product].timeframe[timeframe]) {
-      this.clock.off('tick '+ timeframe, this.series[product].timeframe[timeframe].onSeriesClockTick.bind(this.series[product].timeframe[timeframe]));
+      this.clock.off('tick ' + timeframe, this.series[product].timeframe[timeframe].onSeriesClockTick);
       this.series[product].timeframe[timeframe].off('open',this.seriesOpen.bind(this));
-      this.series[product].timeframe[timeframe].off('close',this.seriesOpen.bind(this));
+      this.series[product].timeframe[timeframe].off('close',this.seriesClose.bind(this));
       delete this.series[product].timeframe[timeframe];
     }
     if (this.series[product].timeframe.lenght == 0) {

--- a/src/Candles.js
+++ b/src/Candles.js
@@ -73,7 +73,7 @@ class candles extends EventEmitter {
       this.series[product].timeframe[timeframe].off('close',this.seriesClose.bind(this));
       delete this.series[product].timeframe[timeframe];
     }
-    if (this.series[product].timeframe.lenght == 0) {
+    if (Object.keys(this.series[product].timeframe).length === 0) {
       delete this.series[product];
     }
   }

--- a/src/Series.js
+++ b/src/Series.js
@@ -13,6 +13,7 @@ class Series extends EventEmitter {
     this.currentCandle = new Candlestick(this.price, this.product, this.timeframe, this.nexttime);
     this.lastClose = null;
     this.price = 0;
+    this.onSeriesClockTick = this.onSeriesClockTick.bind(this)
   }
 
   openSeriesCandle() {


### PR DESCRIPTION
Fixed a broken event listener removal that caused the candle close event to fire even after the product was removed.

In detail:
https://stackoverflow.com/questions/39820651/node-js-eventemitter-how-to-bind-a-class-context-to-the-event-listener-and-then

Also a couple of minor bugs.