### PR TITLE
Fixes for adding, removing, 'current' event, utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ if (data.type === 'match') {
     }
 });
 
-Candlecollection.on('close', candle => {
+Candlecollection.on('close', (candle, candles) => {
   console.log(candle);
 });
 
@@ -191,7 +191,7 @@ This works also for close and current events to.
 like:
 
 ```js
-Candlecollection.on('close BTC-USD 30s', currentCandle, candles => {
+Candlecollection.on('close BTC-USD 30s', (currentCandle, candles) => {
   console.log(currentCandle);
 });
 ```

--- a/src/Candles.js
+++ b/src/Candles.js
@@ -18,7 +18,7 @@ class candles extends EventEmitter {
     this.clock.setOptions(this.options.timediff)
   }
 
-  addProduct(product, timeframe, serieslength=0) {
+  addProduct(product, timeframe, serieslength = 0) {
     if (!product) {
       throw 'product is missing'
     }
@@ -60,7 +60,7 @@ class candles extends EventEmitter {
   }
 
   getTimeDrift() {
-      return this.clock.timediff.drift
+    return this.clock.timediff.drift
   }
 
   removeProduct(product, timeframe) {
@@ -87,7 +87,7 @@ class candles extends EventEmitter {
     delete this.series[product].timeframe[timeframe];
   }
 
-  SetSeriesPrice(product, price, size=0) {
+  SetSeriesPrice(product, price, size = 0) {
     Object.keys(this.series[product].timeframe).forEach(timeframe => {
       if (!this.series[product].timeframe[timeframe]) {
         return;

--- a/src/Candles.js
+++ b/src/Candles.js
@@ -25,23 +25,20 @@ class candles extends EventEmitter {
     if (!timeframe) {
       throw 'timeframe is missing'
     }
-    if (Array.isArray(product)) {
-      product.forEach(product => {
+    (Array.isArray(product) ? product : [product]).forEach(product => {
+      if (!this.series[product]) {
         this.addTimeframe(product, timeframe, serieslength);
-      })
-    } else {
-      this.addTimeframe(product,  timeframe, serieslength);
-    }
+      }
+    })
   };
 
   addTimeframe(product, timeframe, serieslength) {
-    if (Array.isArray(timeframe)) {
-      timeframe.forEach(timeframe => {
-        this.addSeries(product, timeframe, serieslength);
-      })
-    } else {
+    (Array.isArray(timeframe) ? timeframe : [timeframe]).forEach(timeframe => {
+      if (this.series[product]?.timeframe[timeframe]) {
+        return
+      }
       this.addSeries(product, timeframe, serieslength);
-    }
+    })
   }
 
   addSeries(product, timeframe, serieslength) {
@@ -51,8 +48,8 @@ class candles extends EventEmitter {
     }
     var series = new Series(product, timeframe, serieslength);
     this.clock.on('tick ' + timeframe, series.onSeriesClockTick);
-    series.on('open',this.seriesOpen.bind(this));
-    series.on('close',this.seriesClose.bind(this));
+    series.on('open', this.seriesOpen.bind(this));
+    series.on('close', this.seriesClose.bind(this));
     if (!this.series[product]) {
       this.series[product] = {};
     }
@@ -67,15 +64,27 @@ class candles extends EventEmitter {
   }
 
   removeProduct(product, timeframe) {
-    if (this.series[product].timeframe[timeframe]) {
-      this.clock.off('tick ' + timeframe, this.series[product].timeframe[timeframe].onSeriesClockTick);
-      this.series[product].timeframe[timeframe].off('open',this.seriesOpen.bind(this));
-      this.series[product].timeframe[timeframe].off('close',this.seriesClose.bind(this));
-      delete this.series[product].timeframe[timeframe];
-    }
-    if (Object.keys(this.series[product].timeframe).length === 0) {
-      delete this.series[product];
-    }
+    (Array.isArray(product) ? product : [product]).forEach(product => {
+      if (this.series[product]) {
+        this.removeTimeframe(product, timeframe);
+        Object.keys(this.series[product].timeframe).length || delete this.series[product];
+      }
+    })
+  }
+
+  removeTimeframe(product, timeframe) {
+    (Array.isArray(timeframe) ? timeframe : [timeframe]).forEach(timeframe => {
+      if (this.series[product]?.timeframe[timeframe]) {
+        this.removeSeries(product, timeframe)
+      }
+    })
+  }
+
+  removeSeries(product, timeframe) {
+    this.clock.off('tick ' + timeframe, this.series[product].timeframe[timeframe].onSeriesClockTick);
+    this.series[product].timeframe[timeframe].off('open', this.seriesOpen.bind(this));
+    this.series[product].timeframe[timeframe].off('close', this.seriesClose.bind(this));
+    delete this.series[product].timeframe[timeframe];
   }
 
   SetSeriesPrice(product, price, size=0) {
@@ -85,10 +94,10 @@ class candles extends EventEmitter {
       }
       this.series[product].timeframe[timeframe].price = Number.parseFloat(price);
       this.series[product].timeframe[timeframe].currentCandle.updatePrice(Number.parseFloat(price), Number.parseFloat(size).toFixed(8));
-      this.emit('current ' + this.series[product].timeframe[timeframe].product + ' ' + this.series[product].timeframe[timeframe].timeframe, this.series[product].timeframe[timeframe].currentCandle);
-      this.emit('current ' + this.series[product].timeframe[timeframe].product, this.series[product].timeframe[timeframe].currentCandle);
-      this.emit('current ' + this.series[product].timeframe[timeframe].timeframe, this.series[product].timeframe[timeframe].currentCandle);
-      this.emit('current', this.series[product].timeframe[timeframe].currentCandle);
+      this.emit('current ' + this.series[product].timeframe[timeframe].product + ' ' + this.series[product].timeframe[timeframe].timeframe, this.series[product].timeframe[timeframe].currentCandle, this.series[product].timeframe[timeframe].candles);
+      this.emit('current ' + this.series[product].timeframe[timeframe].product, this.series[product].timeframe[timeframe].currentCandle, this.series[product].timeframe[timeframe].candles);
+      this.emit('current ' + this.series[product].timeframe[timeframe].timeframe, this.series[product].timeframe[timeframe].currentCandle, this.series[product].timeframe[timeframe].candles);
+      this.emit('current', this.series[product].timeframe[timeframe].currentCandle, this.series[product].timeframe[timeframe].candles);
     });
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,10 @@ const units = {
   s: 1,
   m: 60,
   h: 3600,
-  d: 86400
+  d: 86400,
+  w: 604800,
+  M: 2592000,
+  y: 31536000
 }
 
 module.exports.timeframeToSec = (timeframe) => {
@@ -21,17 +24,25 @@ module.exports.timeframeToSec = (timeframe) => {
 }
 
 module.exports.secToTimeframe = (secs) => {
-  return;
+  const keys = Object.keys(units);
+  for (let i = keys.length - 1; i >= 0; i--) {
+    let key = keys[i]
+    if (secs % units[key] === 0) {
+      const count = secs / units[key]
+      return count + key;
+    }
+  }
+  return undefined;
 }
 
 module.exports.timeLeft = (epoch, interval) => {
-  return interval - (Math.floor(Number(epoch)/1000) % interval);
+  return interval - (Math.floor(Number(epoch) / 1000) % interval);
 }
 
 module.exports.nextTime = (epoch, interval) => {
-  return (Math.floor(epoch/1000) + this.timeLeft(epoch, interval)) * 1000;
+  return (Math.floor(epoch / 1000) + module.exports.timeLeft(epoch, interval)) * 1000;
 }
 
 module.exports.average = (arr) => {
-  return arr.reduce((acc, val) =>  acc + parseFloat(val, 10), 0) / arr.length;
+  return arr.reduce((acc, val) => acc + parseFloat(val, 10), 0) / arr.length;
 }


### PR DESCRIPTION
addProduct, removeProduct:
Removed if/else and duplicated code when determining product/timeframe type.

removeProduct:
Divided into removeTimeframe and removeSeries similar to adding. Implemented declared but missing support for multiple product/timeframe values. Correct check for the existence of a series.

addTimeframe:
Added check for series existence. When adding series once, this is not necessary, but with repeated calls to addProduct, a situation could arise when the series were overwritten, but the number of event listeners increased.

SetSeriesPrice:
Added declared but missing passing candles to 'current' events.

Also a couple of edits in the readme.